### PR TITLE
Fix compression on files with same-byte blocks

### DIFF
--- a/compress.cpp
+++ b/compress.cpp
@@ -183,7 +183,6 @@ int CompressQuantum(LzCoder *coder, LzTemp *lztemp, MatchLenStorage *mls,
       if (AreAllBytesEqual(src, round_bytes)) {
         float memset_cost = kInvalidCost;
         int n = EncodeArrayU8_Memset(dst, dst_end, src, round_bytes, coder->entropy_opts, coder->speed_tradeoff, coder->platforms, &memset_cost);
-        src += round_bytes;
         dst += n;
         total_cost += memset_cost;
       } else {


### PR DESCRIPTION
This PR is based on the [one I submitted to the original `ooz` by rarten](https://github.com/rarten/ooz/pull/1), intended to fix an issue with compressing some files. The text for that PR is below:

> The line of code to skip over to the next block to compress runs twice when the AreAllBytesEqual test returns true, one on line 184 and another outside the if blocks on line 238. This causes issues when compressing files that have blocks of equal-byte data. This PR removes the extra line to fix compression for these files.

While I don't know if WolvenKit currently uses compression for any files that could cause this bug, I found this issue working on another project and thought the fix could be useful to you too.